### PR TITLE
Fix : order by aggregate function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
  - composer install --no-interaction
 
 script:
- - phpunit
+ - vendor/bin/phpunit
 
 after_script:
  - php vendor/bin/coveralls -v

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,7 +13,10 @@
 >
 
     <php>
-        <var name="db_url" value="mysql://root:@localhost/"/>
+        <var name="db_host" value="localhost" />
+        <var name="db_username" value="root" />
+        <var name="db_password" value="" />
+        <var name="db_driver" value="pdo_mysql"/>
     </php>
 
     <testsuites>

--- a/src/SQLParser/Node/AggregateFunction.php
+++ b/src/SQLParser/Node/AggregateFunction.php
@@ -105,6 +105,25 @@ class AggregateFunction implements NodeInterface
         $this->alias = $alias;
     }
 
+    private $direction;
+
+    public function getDirection()
+    {
+        return $this->direction;
+    }
+
+    /**
+     * Sets the direction.
+     *
+     * @Important
+     *
+     * @param string $direction
+     */
+    public function setDirection($direction)
+    {
+        $this->direction = $direction;
+    }
+
     /**
      * Returns a Mouf instance descriptor describing this object.
      *
@@ -144,6 +163,9 @@ class AggregateFunction implements NodeInterface
                 $alias = is_array($this->alias) ? $this->alias['name'] : $this->alias;
 
                 $sql .= ' AS '.$alias;
+            }
+            if ($this->direction) {
+                $sql .= ' '.$this->direction;
             }
         } else {
             $sql = null;

--- a/src/SQLParser/Node/NodeFactory.php
+++ b/src/SQLParser/Node/NodeFactory.php
@@ -254,12 +254,17 @@ class NodeFactory
                     $expr->setAlias($desc['alias']);
                 }
 
+                if (isset($desc['direction'])) {
+                    $expr->setDirection($desc['direction']);
+                }
+
                 // Debug:
                 unset($desc['base_expr']);
                 unset($desc['expr_type']);
                 unset($desc['sub_tree']);
                 unset($desc['alias']);
                 unset($desc['delim']);
+                unset($desc['direction']);
                 if (!empty($desc)) {
                     error_log('MagicQuery - NodeFactory: Unexpected parameters in aggregate function: '.var_export($desc, true));
                 }

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -152,6 +152,9 @@ class MagicQueryTest extends \PHPUnit_Framework_TestCase
 
         $sql = 'SELECT * FROM users WHERE id IN (1, 3)';
         $this->assertEquals("SELECT * FROM users WHERE id IN (1, 3)", self::simplifySql($magicQuery->build($sql)));
+
+        $sql = 'SELECT country.* FROM country JOIN users ON country.id = users.country_id GROUP BY country.id ORDER BY COUNT(users.id) DESC';
+        $this->assertEquals('SELECT country.* FROM country JOIN users ON (country.id = users.country_id) GROUP BY country.id ORDER BY COUNT(users.id) DESC', self::simplifySql($magicQuery->build($sql)));
     }
 
     /**

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -177,12 +177,13 @@ class MagicQueryTest extends \PHPUnit_Framework_TestCase
     public function testWithCache()
     {
         global $db_url;
-        $config = new \Doctrine\DBAL\Configuration();
-        // TODO: put this in conf variable
         $connectionParams = array(
-            'url' => $db_url,
+            'user' => $GLOBALS['db_username'],
+            'password' => $GLOBALS['db_password'],
+            'host' => $GLOBALS['db_host'],
+            'driver' => $GLOBALS['db_driver'],
         );
-        $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
+        $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams);
 
         $cache = new ArrayCache();
 


### PR DESCRIPTION
Ordering by the result of an aggregate function (`SUM`, `COUNT`, `MAX`, etc) was not supported., therefore only default `ASC` was available.

Error previously logged:

```
MagicQuery - NodeFactory: Unexpected parameters in aggregate function: array (
  'direction' => 'DESC',
)
```