### PR TITLE
Fix logic for parsing MATCH AGAINST statements

### DIFF
--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -329,6 +329,22 @@ class MagicQueryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expectedSql, self::simplifySql($magicQuery->build($sql)));
     }
 
+    public function testMatchAgainst()
+    {
+        $magicQuery = new MagicQuery();
+
+        $sql = "
+            SELECT MATCH(column) AGAINST(:searchTerm IN BOOLEAN MODE) AS rang FROM table
+            WHERE MATCH(column) AGAINST(:searchTerm IN BOOLEAN MODE)
+            ORDER BY MATCH(column) AGAINST(:searchTerm IN BOOLEAN MODE) DESC
+        ";
+        $expectedSql = "SELECT MATCH(column) AGAINST('searchString' IN BOOLEAN MODE) AS rang FROM table WHERE MATCH(column) AGAINST('searchString' IN BOOLEAN MODE) ORDER BY MATCH(column) AGAINST('searchString' IN BOOLEAN MODE) DESC";
+        
+        $params["searchTerm"] = "searchString";
+        
+        $this->assertEquals($expectedSql, self::simplifySql($magicQuery->build($sql, $params)));
+    }
+
     /**
      * @expectedException \Mouf\Database\MagicQueryMissingConnectionException
      */


### PR DESCRIPTION
Hello David!

I found the issue when we try to use MATCH AGAINST statements (fulltext search) in the query.
For example this query string:
`
SELECT ... WHERE MATCH(column) AGAINST('searchString' IN BOOLEAN MODE) ...
`
... converts into:
`
SELECT ... WHERE MATCH(column) AGAINST() 'searchString' ...
`
We can see that 'IN BOOLEAN MODE' disappears and AGAINST params are placed after the function.

It happens because of:
- PHPSQLParser returns 3 nodes for the current query (MATCH, AGAINST and AGAINST params) and MagicQuery just put them one by one in the result string;
```json
[
  { "expr_type": "function", "base_expr": "MATCH", "sub_tree": ... } , 
  { "expr_type": "function", "base_expr": "AGAINST", "no_quotes": ...}, 
  { "expr_type": "match-arguments", "base_expr": "(:serachString IN BOOLEAN MODE)", ...} 
]
```
- MagicQuery parses ExpressionType::MATCH_MODE as a Expression object and not like a ConstNode object and as a result misses it somewhere.

I wrote patch for solving this problem and added the test, please look at it and let me know what do you think of it. Maybe you see how to resolve this issue another way ?

Thank you in advance!
