### PR TITLE
Improving performance

### DIFF
--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -20,6 +20,8 @@ class MagicQueryTest extends \PHPUnit_Framework_TestCase
 
         $sql = 'SELECT id FROM users WHERE name LIKE :name LIMIT 2, :limit';
         $this->assertEquals("SELECT id FROM users WHERE name LIKE 'foo' LIMIT 2, 10", self::simplifySql($magicQuery->build($sql, ['name' => 'foo', 'limit' => 10])));
+        // Test cache
+        $this->assertEquals("SELECT id FROM users WHERE name LIKE 'bar' LIMIT 2, 10", self::simplifySql($magicQuery->build($sql, ['name' => 'bar', 'limit' => 10])));
 
         try {
             $exceptionOccurred = false;


### PR DESCRIPTION
Adding a cache layer on build.
The cache will serve the same SQL if a SQL string with the same parameters set is passed (value of parameters is ignored, only availability is checked)