### PR TITLE
edited the way duplicated foreignKey are detected

### DIFF
--- a/src/Mouf/Database/MagicQuery.php
+++ b/src/Mouf/Database/MagicQuery.php
@@ -221,16 +221,16 @@ class MagicQuery
         // Let's remove the main table from the list of tables to be linked:
         unset($tables[$mainTable]);
 
-        $foreignKeysSet = new \SplObjectStorage();
+        $foreignKeysSet = [];
         $completePath = [];
 
         foreach ($tables as $table) {
             $path = $this->getSchemaAnalyzer()->getShortestPath($mainTable, $table);
             foreach ($path as $foreignKey) {
                 // If the foreign key is not already in our complete path, let's add it.
-                if (!$foreignKeysSet->contains($foreignKey)) {
+                if (!isset($foreignKeysSet[$foreignKey->getName()])) {
                     $completePath[] = $foreignKey;
-                    $foreignKeysSet->attach($foreignKey);
+                    $foreignKeysSet[$foreignKey->getName()] = true;
                 }
             }
         }


### PR DESCRIPTION
Edited the way duplicated foreignKey are detected when constructing the complete path of a magic join.

This solves a hard to track bug where the magic join wouldn't generate a valid FROM clause