### PR TITLE
Case statement in where condition is removed by magic parameters

### DIFF
--- a/src/SQLParser/Node/Expression.php
+++ b/src/SQLParser/Node/Expression.php
@@ -33,6 +33,7 @@
 namespace SQLParser\Node;
 
 use Doctrine\DBAL\Connection;
+use function is_iterable;
 use Mouf\MoufInstanceDescriptor;
 use Mouf\MoufManager;
 use SQLParser\Node\Traverser\NodeTraverser;
@@ -263,10 +264,14 @@ class Expression implements NodeInterface, BypassableInterface
      */
     public function canBeBypassed(array $parameters): bool
     {
-        foreach ($this->subTree as $node) {
-            if (!$node instanceof BypassableInterface || !$node->canBeBypassed($parameters)) {
-                return false;
+        if (is_iterable($this->subTree)) {
+            foreach ($this->subTree as $node) {
+                if (!$node instanceof BypassableInterface || !$node->canBeBypassed($parameters)) {
+                    return false;
+                }
             }
+        } elseif (!$this->subTree instanceof BypassableInterface || !$this->subTree->canBeBypassed($parameters)) {
+            return false;
         }
         return true;
     }

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -177,6 +177,9 @@ class MagicQueryTest extends TestCase
 
         $sql = 'SELECT a FROM users u, users u2';
         $this->assertEquals('SELECT a FROM users AS u CROSS JOIN users AS u2', self::simplifySql($magicQuery->build($sql)));
+
+        $sql = 'SELECT a FROM users u WHERE status = (CASE WHEN u.id = 1 THEN u.status_1 ELSE u.status_2 END)';
+        $this->assertEquals('foo', self::simplifySql($magicQuery->build($sql)));
     }
 
     /**

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -179,7 +179,7 @@ class MagicQueryTest extends TestCase
         $this->assertEquals('SELECT a FROM users AS u CROSS JOIN users AS u2', self::simplifySql($magicQuery->build($sql)));
 
         $sql = 'SELECT a FROM users u WHERE status = (CASE WHEN u.id = 1 THEN u.status_1 ELSE u.status_2 END)';
-        $this->assertEquals('foo', self::simplifySql($magicQuery->build($sql)));
+        $this->assertEquals('SELECT a FROM users AS u WHERE status = (CASE WHEN u.id = 1 THEN u.status_1 ELSE u.status_2 END)', self::simplifySql($magicQuery->build($sql)));
     }
 
     /**


### PR DESCRIPTION
For some reason, the case statement is removed from a where condition.

```
SELECT a FROM users u WHERE status = (CASE WHEN u.id = 1 THEN u.status_1 ELSE u.status_2 END)

=>

SELECT a FROM users u
```

This is a failing test showcasing the issue.