### PR TITLE
Fixing issue with alias and having

### DIFF
--- a/src/SQLParser/Node/Expression.php
+++ b/src/SQLParser/Node/Expression.php
@@ -204,6 +204,9 @@ class Expression implements NodeInterface, BypassableInterface
      */
     public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
     {
+        if (empty($this->subTree)) {
+            return $this->getBaseExpression();
+        }
         $sql = NodeFactory::toSql($this->subTree, $dbConnection, $parameters, $this->delimiter, false, $indent, $conditionsMode, $extrapolateParameters);
 
         if ($sql === null) {
@@ -264,6 +267,10 @@ class Expression implements NodeInterface, BypassableInterface
      */
     public function canBeBypassed(array $parameters): bool
     {
+        if (empty($this->subTree)) {
+            // Some expression can (rarely) have no subtree. Don't know why.
+            return false;
+        }
         if (is_iterable($this->subTree)) {
             foreach ($this->subTree as $node) {
                 if (!$node instanceof BypassableInterface || !$node->canBeBypassed($parameters)) {

--- a/src/SQLParser/Node/NodeFactory.php
+++ b/src/SQLParser/Node/NodeFactory.php
@@ -389,6 +389,7 @@ class NodeFactory
                 unset($desc['alias']);
                 unset($desc['direction']);
                 unset($desc['delim']);
+                unset($desc['no_quotes']);
                 if (!empty($desc)) {
                     error_log('MagicQuery - NodeFactory: Unexpected parameters in exception: '.var_export($desc, true));
                 }

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -180,6 +180,9 @@ class MagicQueryTest extends TestCase
 
         $sql = 'SELECT a FROM users u WHERE status = (CASE WHEN u.id = 1 THEN u.status_1 ELSE u.status_2 END)';
         $this->assertEquals('SELECT a FROM users AS u WHERE status = (CASE WHEN u.id = 1 THEN u.status_1 ELSE u.status_2 END)', self::simplifySql($magicQuery->build($sql)));
+
+        $sql = 'SELECT 42 as fooalias FROM bar HAVING fooalias = 24';
+        $this->assertEquals('SELECT 42 AS fooalias FROM bar HAVING fooalias = 24', self::simplifySql($magicQuery->build($sql)));
     }
 
     /**


### PR DESCRIPTION
When a having clause is using an alias, the "Expression" has no subtree, but a base expression.
We did not cope for this use case until now.