### PR TITLE
Adding an option to choose the SQL dialect generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,15 @@ $conn = \Doctrine\DBAL\DriverManager::getConnection($connectionParams, $config);
 $magicQuery = new \Mouf\Database\MagicQuery($conn);
 ```
 
+Also, if you have no connection to your database configured but you want to generate SQL in some specific dialect, you can
+instead set the DBAL database platform used:
+
+```php
+$magicQuery->setOutputDialect(new \Doctrine\DBAL\Platforms\PostgreSqlPlatform());
+$magicQuery = new \Mouf\Database\MagicQuery();
+```
+
+
 What about performances?
 ------------------------
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 4
+    level: 5
     inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
         - "#Mouf\\\\MoufManager#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 parameters:
-    level: 5
+    level: 6
     inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
         - "#Mouf\\\\MoufManager#"
         - "#Mouf\\\\MoufInstanceDescriptor#"
+        - '#Method Mouf\\Database\\QueryWriter\\Utils\\FindParametersService::findParameters\(\) should return array<string> but returns array<int, int\|string>#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 2
+    level: 3
     inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
         - "#Mouf\\\\MoufManager#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 7
     inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
         - "#Mouf\\\\MoufManager#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 parameters:
     level: 2
+    inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
         - "#Mouf\\\\MoufManager#"
         - "#Mouf\\\\MoufInstanceDescriptor#"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 3
+    level: 4
     inferPrivatePropertyTypeFromConstructor: true
     ignoreErrors:
         - "#Mouf\\\\MoufManager#"

--- a/src/Mouf/Database/MagicQuery.php
+++ b/src/Mouf/Database/MagicQuery.php
@@ -2,6 +2,7 @@
 
 namespace Mouf\Database;
 
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use function array_filter;
 use function array_keys;
 use Doctrine\Common\Cache\VoidCache;
@@ -173,7 +174,8 @@ class MagicQuery
      */
     public function toSql(NodeInterface $sqlNode, array $parameters = array(), bool $extrapolateParameters = true)
     {
-        return $sqlNode->toSql($parameters, $this->connection, 0, SqlRenderInterface::CONDITION_GUESS, $extrapolateParameters);
+        $platform = $this->connection ? $this->connection->getDatabasePlatform() : new MySqlPlatform();
+        return $sqlNode->toSql($parameters, $platform, 0, SqlRenderInterface::CONDITION_GUESS, $extrapolateParameters);
     }
 
     /**

--- a/src/Mouf/Database/MagicQuery.php
+++ b/src/Mouf/Database/MagicQuery.php
@@ -2,6 +2,7 @@
 
 namespace Mouf\Database;
 
+use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use function array_filter;
 use function array_keys;
@@ -175,7 +176,7 @@ class MagicQuery
     public function toSql(NodeInterface $sqlNode, array $parameters = array(), bool $extrapolateParameters = true)
     {
         $platform = $this->connection ? $this->connection->getDatabasePlatform() : new MySqlPlatform();
-        return $sqlNode->toSql($parameters, $platform, 0, SqlRenderInterface::CONDITION_GUESS, $extrapolateParameters);
+        return (string) $sqlNode->toSql($parameters, $platform, 0, SqlRenderInterface::CONDITION_GUESS, $extrapolateParameters);
     }
 
     /**
@@ -286,15 +287,15 @@ class MagicQuery
                 throw new MagicQueryMissingConnectionException('In order to use MagicJoin, you need to configure a DBAL connection.');
             }
 
-            $this->schemaAnalyzer = new SchemaAnalyzer($this->connection->getSchemaManager(), $this->cache, $this->getConnectionUniqueId());
+            $this->schemaAnalyzer = new SchemaAnalyzer($this->connection->getSchemaManager(), $this->cache, $this->getConnectionUniqueId($this->connection));
         }
 
         return $this->schemaAnalyzer;
     }
 
-    private function getConnectionUniqueId()
+    private function getConnectionUniqueId(Connection $connection)
     {
-        return hash('md4', $this->connection->getHost().'-'.$this->connection->getPort().'-'.$this->connection->getDatabase().'-'.$this->connection->getDriver()->getName());
+        return hash('md4', $connection->getHost().'-'.$connection->getPort().'-'.$connection->getDatabase().'-'.$connection->getDriver()->getName());
     }
 
     /**

--- a/src/Mouf/Database/QueryWriter/QueryResult.php
+++ b/src/Mouf/Database/QueryWriter/QueryResult.php
@@ -75,7 +75,7 @@ class QueryResult implements ArrayValueInterface, PaginableInterface, SortableIn
     public function val()
     {
         $parameters = ValueUtils::val($this->parameters);
-        $pdoStatement = $this->connection->query($this->select->toSql($parameters, $this->connection).DbHelper::getFromLimitString($this->offset, $this->limit));
+        $pdoStatement = $this->connection->query($this->select->toSql($parameters, $this->connection->getDatabasePlatform()).DbHelper::getFromLimitString($this->offset, $this->limit));
 
         return new ResultSet($pdoStatement);
     }
@@ -89,7 +89,7 @@ class QueryResult implements ArrayValueInterface, PaginableInterface, SortableIn
     {
         $parameters = ValueUtils::val($this->parameters);
 
-        return $this->select->toSql($parameters, $this->connection);
+        return $this->select->toSql($parameters, $this->connection->getDatabasePlatform());
     }
 
     /**

--- a/src/Mouf/Database/QueryWriter/QueryResult.php
+++ b/src/Mouf/Database/QueryWriter/QueryResult.php
@@ -133,9 +133,9 @@ class QueryResult implements ArrayValueInterface, PaginableInterface, SortableIn
      *
      * @param string $key
      *
-     * @return NodeInterface
+     * @return NodeInterface|null
      */
-    private function findColumnByKey($key)
+    private function findColumnByKey($key): ?NodeInterface
     {
         $columns = $this->select->getColumns();
         foreach ($columns as $column) {
@@ -152,6 +152,6 @@ class QueryResult implements ArrayValueInterface, PaginableInterface, SortableIn
             }
         }
 
-        return;
+        return null;
     }
 }

--- a/src/Mouf/Database/QueryWriter/QueryResult.php
+++ b/src/Mouf/Database/QueryWriter/QueryResult.php
@@ -83,7 +83,7 @@ class QueryResult implements ArrayValueInterface, PaginableInterface, SortableIn
     /**
      * Returns the SQL for this query-result (without pagination, but with parameters accounted for).
      *
-     * @return string
+     * @return string|null
      */
     public function toSql()
     {

--- a/src/Mouf/Database/QueryWriter/ResultSet.php
+++ b/src/Mouf/Database/QueryWriter/ResultSet.php
@@ -2,6 +2,8 @@
 
 namespace Mouf\Database\QueryWriter;
 
+use Doctrine\DBAL\Statement;
+
 /**
  * Wraps the results of a PDOStatement.
  *
@@ -10,7 +12,7 @@ namespace Mouf\Database\QueryWriter;
 class ResultSet implements \Iterator
 {
     /**
-     * @var \PDOStatement
+     * @var \PDOStatement|Statement
      */
     private $statement;
     private $castToClass;
@@ -19,7 +21,7 @@ class ResultSet implements \Iterator
     private $fetched = false;
     private $rewindCalls = 0;
 
-    public function __construct(\PDOStatement $statement, $castToClass = '')
+    public function __construct($statement, $castToClass = '')
     {
         $this->statement = $statement;
         $this->castToClass = $castToClass;

--- a/src/SQLParser/Node/AbstractManyInstancesOperator.php
+++ b/src/SQLParser/Node/AbstractManyInstancesOperator.php
@@ -64,7 +64,7 @@ abstract class AbstractManyInstancesOperator implements NodeInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sqlOperands = array();
         foreach ($this->operands as $operand) {

--- a/src/SQLParser/Node/AbstractManyInstancesOperator.php
+++ b/src/SQLParser/Node/AbstractManyInstancesOperator.php
@@ -2,7 +2,7 @@
 
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufManager;
 use Mouf\MoufInstanceDescriptor;
 use SQLParser\Node\Traverser\NodeTraverser;
@@ -56,18 +56,19 @@ abstract class AbstractManyInstancesOperator implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sqlOperands = array();
         foreach ($this->operands as $operand) {
-            $sql = NodeFactory::toSql($operand, $dbConnection, $parameters, ' ', true, $indent, $conditionsMode, $extrapolateParameters);
+            $sql = NodeFactory::toSql($operand, $platform, $parameters, ' ', true, $indent, $conditionsMode, $extrapolateParameters);
             if ($sql != null) {
                 $sqlOperands[] = $sql;
             }

--- a/src/SQLParser/Node/AbstractTwoOperandsOperator.php
+++ b/src/SQLParser/Node/AbstractTwoOperandsOperator.php
@@ -97,7 +97,7 @@ abstract class AbstractTwoOperandsOperator implements NodeInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         if ($conditionsMode == self::CONDITION_GUESS) {
             $bypass = false;

--- a/src/SQLParser/Node/AggregateFunction.php
+++ b/src/SQLParser/Node/AggregateFunction.php
@@ -152,7 +152,7 @@ class AggregateFunction implements NodeInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $subTreeSql = NodeFactory::toSql($this->subTree, $platform, $parameters, ', ', false, $indent, $conditionsMode, $extrapolateParameters);
         if ($subTreeSql !== null) {

--- a/src/SQLParser/Node/AggregateFunction.php
+++ b/src/SQLParser/Node/AggregateFunction.php
@@ -32,7 +32,7 @@
  */
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufManager;
 use Mouf\MoufInstanceDescriptor;
 use SQLParser\Node\Traverser\NodeTraverser;
@@ -144,16 +144,17 @@ class AggregateFunction implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param \SQLParser\Node\AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
-        $subTreeSql = NodeFactory::toSql($this->subTree, $dbConnection, $parameters, ', ', false, $indent, $conditionsMode, $extrapolateParameters);
+        $subTreeSql = NodeFactory::toSql($this->subTree, $platform, $parameters, ', ', false, $indent, $conditionsMode, $extrapolateParameters);
         if ($subTreeSql !== null) {
             $sql = $this->functionName.'(';
             $sql .= $subTreeSql;

--- a/src/SQLParser/Node/AggregateFunction.php
+++ b/src/SQLParser/Node/AggregateFunction.php
@@ -145,7 +145,7 @@ class AggregateFunction implements NodeInterface
      * Renders the object as a SQL string.
      *
      * @param array $parameters
-     * @param \SQLParser\Node\AbstractPlatform $platform
+     * @param AbstractPlatform $platform
      * @param int $indent
      * @param int $conditionsMode
      *

--- a/src/SQLParser/Node/Between.php
+++ b/src/SQLParser/Node/Between.php
@@ -2,7 +2,8 @@
 
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
 use Mouf\MoufManager;
 use Mouf\MoufInstanceDescriptor;
 use Mouf\Utils\Common\ConditionInterface\ConditionInterface;
@@ -145,14 +146,15 @@ class Between implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $minBypass = false;
         $maxBypass = false;
@@ -182,19 +184,19 @@ class Between implements NodeInterface
         }
 
         if (!$minBypass && !$maxBypass) {
-            $sql = NodeFactory::toSql($this->leftOperand, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+            $sql = NodeFactory::toSql($this->leftOperand, $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
             $sql .= ' BETWEEN ';
-            $sql .= NodeFactory::toSql($this->minValueOperand, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+            $sql .= NodeFactory::toSql($this->minValueOperand, $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
             $sql .= ' AND ';
-            $sql .= NodeFactory::toSql($this->maxValueOperand, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+            $sql .= NodeFactory::toSql($this->maxValueOperand, $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
         } elseif (!$minBypass && $maxBypass) {
-            $sql = NodeFactory::toSql($this->leftOperand, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+            $sql = NodeFactory::toSql($this->leftOperand, $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
             $sql .= ' >= ';
-            $sql .= NodeFactory::toSql($this->minValueOperand, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+            $sql .= NodeFactory::toSql($this->minValueOperand, $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
         } elseif ($minBypass && !$maxBypass) {
-            $sql = NodeFactory::toSql($this->leftOperand, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+            $sql = NodeFactory::toSql($this->leftOperand, $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
             $sql .= ' <= ';
-            $sql .= NodeFactory::toSql($this->maxValueOperand, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+            $sql .= NodeFactory::toSql($this->maxValueOperand, $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
         } else {
             $sql = null;
         }

--- a/src/SQLParser/Node/Between.php
+++ b/src/SQLParser/Node/Between.php
@@ -79,7 +79,7 @@ class Between implements NodeInterface
     }
 
     /**
-     * @var ConditionInterface
+     * @var ConditionInterface|null
      */
     protected $minValueCondition;
 
@@ -96,7 +96,7 @@ class Between implements NodeInterface
     }
 
     /**
-     * @var ConditionInterface
+     * @var ConditionInterface|null
      */
     protected $maxValueCondition;
 

--- a/src/SQLParser/Node/Between.php
+++ b/src/SQLParser/Node/Between.php
@@ -37,17 +37,17 @@ class Between implements NodeInterface
     }
 
     /**
-     * @var string|NodeInterface|NodeInterface[]
+     * @var NodeInterface
      */
     private $minValueOperand;
 
     /**
-     * @var string|NodeInterface|NodeInterface[]
+     * @var NodeInterface
      */
     private $maxValueOperand;
 
     /**
-     * @return NodeInterface|NodeInterface[]|string
+     * @return NodeInterface
      */
     public function getMinValueOperand()
     {
@@ -55,15 +55,15 @@ class Between implements NodeInterface
     }
 
     /**
-     * @param NodeInterface|NodeInterface[]|string $minValueOperand
+     * @param NodeInterface $minValueOperand
      */
-    public function setMinValueOperand($minValueOperand)
+    public function setMinValueOperand(NodeInterface $minValueOperand)
     {
         $this->minValueOperand = $minValueOperand;
     }
 
     /**
-     * @return NodeInterface|NodeInterface[]|string
+     * @return NodeInterface
      */
     public function getMaxValueOperand()
     {
@@ -71,9 +71,9 @@ class Between implements NodeInterface
     }
 
     /**
-     * @param NodeInterface|NodeInterface[]|string $maxValueOperand
+     * @param NodeInterface $maxValueOperand
      */
-    public function setMaxValueOperand($maxValueOperand)
+    public function setMaxValueOperand(NodeInterface $maxValueOperand)
     {
         $this->maxValueOperand = $maxValueOperand;
     }
@@ -154,7 +154,7 @@ class Between implements NodeInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $minBypass = false;
         $maxBypass = false;

--- a/src/SQLParser/Node/CaseOperation.php
+++ b/src/SQLParser/Node/CaseOperation.php
@@ -60,7 +60,7 @@ class CaseOperation implements NodeInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = 'CASE '.NodeFactory::toSql($this->operation, $platform, $parameters, ' ', false, $indent, $conditionsMode).' END';
 

--- a/src/SQLParser/Node/CaseOperation.php
+++ b/src/SQLParser/Node/CaseOperation.php
@@ -2,7 +2,7 @@
 
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufManager;
 use Mouf\MoufInstanceDescriptor;
 use SQLParser\Node\Traverser\NodeTraverser;
@@ -52,16 +52,17 @@ class CaseOperation implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
-        $sql = 'CASE '.NodeFactory::toSql($this->operation, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode).' END';
+        $sql = 'CASE '.NodeFactory::toSql($this->operation, $platform, $parameters, ' ', false, $indent, $conditionsMode).' END';
 
         return $sql;
     }

--- a/src/SQLParser/Node/ColRef.php
+++ b/src/SQLParser/Node/ColRef.php
@@ -192,7 +192,7 @@ class ColRef implements NodeInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = '';
         if ($this->database) {

--- a/src/SQLParser/Node/ColRef.php
+++ b/src/SQLParser/Node/ColRef.php
@@ -32,7 +32,7 @@
  */
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufManager;
 use Mouf\MoufInstanceDescriptor;
 use SQLParser\Node\Traverser\VisitorInterface;
@@ -184,24 +184,25 @@ class ColRef implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = '';
         if ($this->database) {
-            $sql .= NodeFactory::escapeDBItem($this->database, $dbConnection).'.';
+            $sql .= $platform->quoteSingleIdentifier($this->database).'.';
         }
         if ($this->table) {
-            $sql .= NodeFactory::escapeDBItem($this->table, $dbConnection).'.';
+            $sql .= $platform->quoteSingleIdentifier($this->table).'.';
         }
         if ($this->column !== '*') {
-            $sql .= NodeFactory::escapeDBItem($this->column, $dbConnection);
+            $sql .= $platform->quoteSingleIdentifier($this->column);
         } else {
             $sql .= '*';
         }

--- a/src/SQLParser/Node/ConstNode.php
+++ b/src/SQLParser/Node/ConstNode.php
@@ -32,7 +32,7 @@
  */
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufManager;
 use Mouf\MoufInstanceDescriptor;
 use SQLParser\Node\Traverser\VisitorInterface;
@@ -98,23 +98,22 @@ class ConstNode implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         if ($this->value === null) {
             return 'NULL';
         } elseif (!$this->isString) {
             return $this->value;
-        } elseif ($dbConnection != null) {
-            return $dbConnection->quote($this->value);
         } else {
-            return "'".addslashes($this->value)."'";
+            return $platform->quoteStringLiteral($this->value);
         }
     }
 

--- a/src/SQLParser/Node/ConstNode.php
+++ b/src/SQLParser/Node/ConstNode.php
@@ -106,7 +106,7 @@ class ConstNode implements NodeInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         if ($this->value === null) {
             return 'NULL';

--- a/src/SQLParser/Node/Different.php
+++ b/src/SQLParser/Node/Different.php
@@ -2,7 +2,7 @@
 
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * This class represents a Is operation in an SQL expression.
@@ -21,7 +21,7 @@ class Different extends AbstractTwoOperandsOperator
         return '<>';
     }
 
-    protected function getSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    protected function getSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
     {
         $rightOperand = $this->getRightOperand();
         if ($rightOperand instanceof Parameter && !isset($parameters[$rightOperand->getName()])) {
@@ -30,12 +30,12 @@ class Different extends AbstractTwoOperandsOperator
             $isNull = false;
         }
 
-        $sql = NodeFactory::toSql($this->getLeftOperand(), $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+        $sql = NodeFactory::toSql($this->getLeftOperand(), $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
         if ($isNull) {
             $sql .= ' IS NOT null';
         } else {
             $sql .= ' '.$this->getOperatorSymbol().' ';
-            $sql .= NodeFactory::toSql($rightOperand, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+            $sql .= NodeFactory::toSql($rightOperand, $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
         }
 
         return $sql;

--- a/src/SQLParser/Node/Equal.php
+++ b/src/SQLParser/Node/Equal.php
@@ -2,7 +2,7 @@
 
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * This class represents an = operation in an SQL expression.
@@ -19,7 +19,7 @@ class Equal extends AbstractTwoOperandsOperator
         return '=';
     }
 
-    protected function getSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    protected function getSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
     {
         $rightOperand = $this->getRightOperand();
         if ($rightOperand instanceof Parameter && !isset($parameters[$rightOperand->getName()])) {
@@ -28,12 +28,12 @@ class Equal extends AbstractTwoOperandsOperator
             $isNull = false;
         }
 
-        $sql = NodeFactory::toSql($this->getLeftOperand(), $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+        $sql = NodeFactory::toSql($this->getLeftOperand(), $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
         if ($isNull) {
             $sql .= ' IS null';
         } else {
             $sql .= ' '.$this->getOperatorSymbol().' ';
-            $sql .= NodeFactory::toSql($rightOperand, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+            $sql .= NodeFactory::toSql($rightOperand, $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
         }
 
         return $sql;

--- a/src/SQLParser/Node/Expression.php
+++ b/src/SQLParser/Node/Expression.php
@@ -32,7 +32,7 @@
  */
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use function is_iterable;
 use Mouf\MoufInstanceDescriptor;
 use Mouf\MoufManager;
@@ -195,19 +195,20 @@ class Expression implements NodeInterface, BypassableInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string|null
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         if (empty($this->subTree)) {
             return $this->getBaseExpression();
         }
-        $sql = NodeFactory::toSql($this->subTree, $dbConnection, $parameters, $this->delimiter, false, $indent, $conditionsMode, $extrapolateParameters);
+        $sql = NodeFactory::toSql($this->subTree, $platform, $parameters, $this->delimiter, false, $indent, $conditionsMode, $extrapolateParameters);
 
         if ($sql === null) {
             return null;

--- a/src/SQLParser/Node/Expression.php
+++ b/src/SQLParser/Node/Expression.php
@@ -203,7 +203,7 @@ class Expression implements NodeInterface, BypassableInterface
      * @param bool $extrapolateParameters
      * @return string|null
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         if (empty($this->subTree)) {
             return $this->getBaseExpression();

--- a/src/SQLParser/Node/In.php
+++ b/src/SQLParser/Node/In.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace SQLParser\Node;
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\Database\MagicQueryException;
 
 /**
@@ -21,7 +21,7 @@ class In extends AbstractTwoOperandsOperator
         return 'IN';
     }
 
-    protected function getSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    protected function getSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
     {
         $rightOperand = $this->getRightOperand();
 
@@ -40,7 +40,7 @@ class In extends AbstractTwoOperandsOperator
             }
         }
 
-        return parent::getSql($parameters, $dbConnection, $indent, $conditionsMode, $extrapolateParameters);
+        return parent::getSql($parameters, $platform, $indent, $conditionsMode, $extrapolateParameters);
     }
 
     protected function refactorParameterToExpression(NodeInterface $rightOperand): NodeInterface

--- a/src/SQLParser/Node/LimitNode.php
+++ b/src/SQLParser/Node/LimitNode.php
@@ -98,7 +98,7 @@ class LimitNode implements NodeInterface
         }
 
         if (is_numeric($this->value)) {
-            return (int) $this->value;
+            return (string) ((int) $this->value);
         } elseif (empty($this->value)) {
             return null;
         } else {

--- a/src/SQLParser/Node/LimitNode.php
+++ b/src/SQLParser/Node/LimitNode.php
@@ -83,7 +83,7 @@ class LimitNode implements NodeInterface
      *
      * @param array $parameters
      * @param AbstractPlatform $platform
-     * @param int|number $indent
+     * @param int $indent
      * @param int $conditionsMode
      *
      * @param bool $extrapolateParameters
@@ -91,7 +91,7 @@ class LimitNode implements NodeInterface
      *
      * @throws \Exception
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         if ($this->value === null) {
             throw new \Exception('A limit parameter must be an integer');

--- a/src/SQLParser/Node/LimitNode.php
+++ b/src/SQLParser/Node/LimitNode.php
@@ -32,7 +32,7 @@
  */
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufManager;
 use Mouf\MoufInstanceDescriptor;
 use SQLParser\Node\Traverser\VisitorInterface;
@@ -81,16 +81,17 @@ class LimitNode implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param array      $parameters
-     * @param Connection $dbConnection
+     * @param array $parameters
+     * @param AbstractPlatform $platform
      * @param int|number $indent
-     * @param int        $conditionsMode
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      *
      * @throws \Exception
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         if ($this->value === null) {
             throw new \Exception('A limit parameter must be an integer');
@@ -98,10 +99,10 @@ class LimitNode implements NodeInterface
 
         if (is_numeric($this->value)) {
             return (int) $this->value;
-        } elseif ($dbConnection != null) {
-            return $dbConnection->quote($this->value);
+        } elseif (empty($this->value)) {
+            return null;
         } else {
-            return addslashes($this->value);
+            return $platform->quoteStringLiteral($this->value);
         }
     }
 

--- a/src/SQLParser/Node/NodeFactory.php
+++ b/src/SQLParser/Node/NodeFactory.php
@@ -848,7 +848,7 @@ class NodeFactory
      * @param array       $parameters
      * @param string      $delimiter
      * @param bool|string $wrapInBrackets
-     * @param int|number  $indent
+     * @param int         $indent
      * @param int         $conditionsMode
      *
      * @return null|string

--- a/src/SQLParser/Node/NodeFactory.php
+++ b/src/SQLParser/Node/NodeFactory.php
@@ -844,7 +844,7 @@ class NodeFactory
      * Tansforms the array of nodes (or the node) passed in parameter into a SQL string.
      *
      * @param mixed       $nodes          Recursive array of node interface
-     * @param Connection  $platform
+     * @param AbstractPlatform  $platform
      * @param array       $parameters
      * @param string      $delimiter
      * @param bool|string $wrapInBrackets
@@ -853,7 +853,7 @@ class NodeFactory
      *
      * @return null|string
      */
-    public static function toSql($nodes, AbstractPlatform $platform = null, array $parameters = array(), $delimiter = ',', $wrapInBrackets = true, $indent = 0, $conditionsMode = SqlRenderInterface::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public static function toSql($nodes, AbstractPlatform $platform, array $parameters = array(), $delimiter = ',', $wrapInBrackets = true, $indent = 0, $conditionsMode = SqlRenderInterface::CONDITION_APPLY, bool $extrapolateParameters = true)
     {
         if (is_array($nodes)) {
             $elems = array();

--- a/src/SQLParser/Node/Operator.php
+++ b/src/SQLParser/Node/Operator.php
@@ -32,7 +32,7 @@
  */
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufInstanceDescriptor;
 use Mouf\MoufManager;
 use SQLParser\Node\Traverser\VisitorInterface;
@@ -81,14 +81,15 @@ class Operator implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         return $this->value;
     }

--- a/src/SQLParser/Node/Operator.php
+++ b/src/SQLParser/Node/Operator.php
@@ -89,7 +89,7 @@ class Operator implements NodeInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         return $this->value;
     }

--- a/src/SQLParser/Node/Parameter.php
+++ b/src/SQLParser/Node/Parameter.php
@@ -160,7 +160,7 @@ class Parameter implements NodeInterface, BypassableInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         if ($extrapolateParameters && isset($parameters[$this->name])) {
             if ($parameters[$this->name] === null) {

--- a/src/SQLParser/Node/Reserved.php
+++ b/src/SQLParser/Node/Reserved.php
@@ -111,13 +111,13 @@ class Reserved implements NodeInterface
      *
      * @param array $parameters
      * @param AbstractPlatform $platform
-     * @param int|number $indent
+     * @param int $indent
      * @param int $conditionsMode
      *
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = '';
 

--- a/src/SQLParser/Node/Reserved.php
+++ b/src/SQLParser/Node/Reserved.php
@@ -32,7 +32,7 @@
  */
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufInstanceDescriptor;
 use Mouf\MoufManager;
 use SQLParser\Node\Traverser\VisitorInterface;
@@ -109,14 +109,15 @@ class Reserved implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param array      $parameters
-     * @param Connection $dbConnection
+     * @param array $parameters
+     * @param AbstractPlatform $platform
      * @param int|number $indent
-     * @param int        $conditionsMode
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = '';
 

--- a/src/SQLParser/Node/SimpleFunction.php
+++ b/src/SQLParser/Node/SimpleFunction.php
@@ -32,7 +32,7 @@
  */
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufInstanceDescriptor;
 use Mouf\MoufManager;
 use SQLParser\Node\Traverser\NodeTraverser;
@@ -158,20 +158,21 @@ class SimpleFunction implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = '';
         if (!empty($this->baseExpression)) {
             $sql .= $this->baseExpression.'(';
         }
-        $sql .= NodeFactory::toSql($this->subTree, $dbConnection, $parameters, ',', false, $indent, $conditionsMode, $extrapolateParameters);
+        $sql .= NodeFactory::toSql($this->subTree, $platform, $parameters, ',', false, $indent, $conditionsMode, $extrapolateParameters);
         if (!empty($this->baseExpression)) {
             $sql .= ')';
         }

--- a/src/SQLParser/Node/SimpleFunction.php
+++ b/src/SQLParser/Node/SimpleFunction.php
@@ -166,7 +166,7 @@ class SimpleFunction implements NodeInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = '';
         if (!empty($this->baseExpression)) {

--- a/src/SQLParser/Node/SubQuery.php
+++ b/src/SQLParser/Node/SubQuery.php
@@ -32,7 +32,7 @@
  */
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use SQLParser\Node\Traverser\NodeTraverser;
 use SQLParser\Node\Traverser\VisitorInterface;
 use SQLParser\Query\Select;
@@ -180,26 +180,27 @@ class SubQuery implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = '';
         if ($this->refClause) {
             $sql .= "\n  ".$this->joinType.' ';
         }
-        $sql .= '('.$this->subQuery->toSql($parameters, $dbConnection, $indent, $conditionsMode, $extrapolateParameters).')';
+        $sql .= '('.$this->subQuery->toSql($parameters, $platform, $indent, $conditionsMode, $extrapolateParameters).')';
         if ($this->alias) {
-            $sql .= ' AS '.NodeFactory::escapeDBItem($this->alias, $dbConnection);
+            $sql .= ' AS '.$platform->quoteSingleIdentifier($this->alias);
         }
         if ($this->refClause) {
             $sql .= ' ON ';
-            $sql .= NodeFactory::toSql($this->refClause, $dbConnection, $parameters, ' ', true, $indent, $conditionsMode, $extrapolateParameters);
+            $sql .= NodeFactory::toSql($this->refClause, $platform, $parameters, ' ', true, $indent, $conditionsMode, $extrapolateParameters);
         }
 
         return $sql;

--- a/src/SQLParser/Node/SubQuery.php
+++ b/src/SQLParser/Node/SubQuery.php
@@ -188,7 +188,7 @@ class SubQuery implements NodeInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = '';
         if ($this->refClause) {

--- a/src/SQLParser/Node/Table.php
+++ b/src/SQLParser/Node/Table.php
@@ -193,7 +193,7 @@ class Table implements NodeInterface
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = '';
         if ($this->refClause || $this->joinType === 'CROSS JOIN') {

--- a/src/SQLParser/Node/Table.php
+++ b/src/SQLParser/Node/Table.php
@@ -32,7 +32,7 @@
  */
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufInstanceDescriptor;
 use Mouf\MoufManager;
 use SQLParser\Node\Traverser\NodeTraverser;
@@ -185,29 +185,30 @@ class Table implements NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = '';
         if ($this->refClause || $this->joinType === 'CROSS JOIN') {
             $sql .= "\n  ".$this->joinType.' ';
         }
         if ($this->database) {
-            $sql .= NodeFactory::escapeDBItem($this->database, $dbConnection).'.';
+            $sql .= $platform->quoteSingleIdentifier($this->database).'.';
         }
-        $sql .= NodeFactory::escapeDBItem($this->table, $dbConnection);
+        $sql .= $platform->quoteSingleIdentifier($this->table);
         if ($this->alias) {
-            $sql .= ' AS '.NodeFactory::escapeDBItem($this->alias, $dbConnection);
+            $sql .= ' AS '.$platform->quoteSingleIdentifier($this->alias);
         }
         if ($this->refClause) {
             $sql .= ' ON ';
-            $sql .= NodeFactory::toSql($this->refClause, $dbConnection, $parameters, ' ', true, $indent, $conditionsMode, $extrapolateParameters);
+            $sql .= NodeFactory::toSql($this->refClause, $platform, $parameters, ' ', true, $indent, $conditionsMode, $extrapolateParameters);
         }
 
         return $sql;

--- a/src/SQLParser/Node/UnquotedParameter.php
+++ b/src/SQLParser/Node/UnquotedParameter.php
@@ -55,7 +55,7 @@ class UnquotedParameter extends Parameter
     public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $name = parent::toSql($parameters, $platform, $indent, $conditionsMode, $extrapolateParameters);
-        $name = str_replace("'", '', $name);
+        $name = str_replace("'", '', $name ?? '');
 
         return $name;
     }

--- a/src/SQLParser/Node/UnquotedParameter.php
+++ b/src/SQLParser/Node/UnquotedParameter.php
@@ -46,13 +46,13 @@ class UnquotedParameter extends Parameter
      *
      * @param array $parameters
      * @param AbstractPlatform $platform
-     * @param int|number $indent
+     * @param int $indent
      * @param int $conditionsMode
      *
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $name = parent::toSql($parameters, $platform, $indent, $conditionsMode, $extrapolateParameters);
         $name = str_replace("'", '', $name);

--- a/src/SQLParser/Node/UnquotedParameter.php
+++ b/src/SQLParser/Node/UnquotedParameter.php
@@ -32,7 +32,7 @@
  */
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * This class represents a parameter (as in parameterized query).
@@ -44,16 +44,17 @@ class UnquotedParameter extends Parameter
     /**
      * Renders the object as a SQL string without quote if its a numeric.
      *
-     * @param array      $parameters
-     * @param Connection $dbConnection
+     * @param array $parameters
+     * @param AbstractPlatform $platform
      * @param int|number $indent
-     * @param int        $conditionsMode
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
-        $name = parent::toSql($parameters, $dbConnection, $indent, $conditionsMode, $extrapolateParameters);
+        $name = parent::toSql($parameters, $platform, $indent, $conditionsMode, $extrapolateParameters);
         $name = str_replace("'", '', $name);
 
         return $name;

--- a/src/SQLParser/Node/WhenConditions.php
+++ b/src/SQLParser/Node/WhenConditions.php
@@ -2,7 +2,7 @@
 
 namespace SQLParser\Node;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * This class represents a set of ... WHEN ... THEN ... construct (inside a CASE).
@@ -33,23 +33,24 @@ class WhenConditions extends AbstractManyInstancesOperator
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param number     $indent
-     * @param int        $conditionsMode
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $fullSql = '';
 
         if ($this->value) {
-            $fullSql = NodeFactory::toSql($this->value, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+            $fullSql = NodeFactory::toSql($this->value, $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
         }
 
         foreach ($this->getOperands() as $operand) {
-            $sql = NodeFactory::toSql($operand, $dbConnection, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
+            $sql = NodeFactory::toSql($operand, $platform, $parameters, ' ', false, $indent, $conditionsMode, $extrapolateParameters);
             if ($sql != null) {
                 $fullSql .= "\n".str_repeat(' ', $indent).'WHEN '.$sql;
             }

--- a/src/SQLParser/Node/WhenConditions.php
+++ b/src/SQLParser/Node/WhenConditions.php
@@ -41,7 +41,7 @@ class WhenConditions extends AbstractManyInstancesOperator
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $fullSql = '';
 

--- a/src/SQLParser/Query/Select.php
+++ b/src/SQLParser/Query/Select.php
@@ -33,6 +33,7 @@
 namespace SQLParser\Query;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufInstanceDescriptor;
 use SQLParser\Node\NodeFactory;
 use Mouf\MoufManager;
@@ -315,14 +316,15 @@ class Select implements StatementInterface, NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param array      $parameters
-     * @param Connection $dbConnection
+     * @param array $parameters
+     * @param AbstractPlatform $platform
      * @param int|number $indent
-     * @param int        $conditionsMode
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = 'SELECT ';
         if ($this->distinct) {
@@ -333,39 +335,39 @@ class Select implements StatementInterface, NodeInterface
         }
 
         if (!empty($this->columns)) {
-            $sql .= NodeFactory::toSql($this->columns, $dbConnection, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
+            $sql .= NodeFactory::toSql($this->columns, $platform, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
         }
 
         if (!empty($this->from)) {
-            $from = NodeFactory::toSql($this->from, $dbConnection, $parameters, ' ', false, $indent + 2, $conditionsMode, $extrapolateParameters);
+            $from = NodeFactory::toSql($this->from, $platform, $parameters, ' ', false, $indent + 2, $conditionsMode, $extrapolateParameters);
             if ($from) {
                 $sql .= "\nFROM ".$from;
             }
         }
 
         if (!empty($this->where)) {
-            $where = NodeFactory::toSql($this->where, $dbConnection, $parameters, ' ', false, $indent + 2, $conditionsMode, $extrapolateParameters);
+            $where = NodeFactory::toSql($this->where, $platform, $parameters, ' ', false, $indent + 2, $conditionsMode, $extrapolateParameters);
             if ($where) {
                 $sql .= "\nWHERE ".$where;
             }
         }
 
         if (!empty($this->group)) {
-            $groupBy = NodeFactory::toSql($this->group, $dbConnection, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
+            $groupBy = NodeFactory::toSql($this->group, $platform, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
             if ($groupBy) {
                 $sql .= "\nGROUP BY ".$groupBy;
             }
         }
 
         if (!empty($this->having)) {
-            $having = NodeFactory::toSql($this->having, $dbConnection, $parameters, ' ', false, $indent + 2, $conditionsMode, $extrapolateParameters);
+            $having = NodeFactory::toSql($this->having, $platform, $parameters, ' ', false, $indent + 2, $conditionsMode, $extrapolateParameters);
             if ($having) {
                 $sql .= "\nHAVING ".$having;
             }
         }
 
         if (!empty($this->order)) {
-            $order = NodeFactory::toSql($this->order, $dbConnection, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
+            $order = NodeFactory::toSql($this->order, $platform, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
             if ($order) {
                 $sql .= "\nORDER BY ".$order;
             }
@@ -374,7 +376,7 @@ class Select implements StatementInterface, NodeInterface
         if (!empty($this->offset) && empty($this->limit)) {
             throw new \Exception('There is no offset if no limit is provided. An error may have occurred during SQLParsing.');
         } elseif (!empty($this->limit)) {
-            $limit = NodeFactory::toSql($this->limit, $dbConnection, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
+            $limit = NodeFactory::toSql($this->limit, $platform, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
             if ($limit === '' || ($extrapolateParameters && substr(trim($limit), 0, 1) == ':')) {
                 $limit = null;
             }
@@ -382,7 +384,7 @@ class Select implements StatementInterface, NodeInterface
                 $limit = null;
             }
             if (!empty($this->offset)) {
-                $offset = NodeFactory::toSql($this->offset, $dbConnection, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
+                $offset = NodeFactory::toSql($this->offset, $platform, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
                 if ($offset === '' || ($extrapolateParameters && substr(trim($offset), 0, 1) == ':')) {
                     $offset = null;
                 }

--- a/src/SQLParser/Query/Select.php
+++ b/src/SQLParser/Query/Select.php
@@ -377,7 +377,7 @@ class Select implements StatementInterface, NodeInterface
             throw new \Exception('There is no offset if no limit is provided. An error may have occurred during SQLParsing.');
         } elseif (!empty($this->limit)) {
             $limit = NodeFactory::toSql($this->limit, $platform, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
-            if ($limit === '' || ($extrapolateParameters && substr(trim($limit), 0, 1) == ':')) {
+            if ($limit === '' || ($extrapolateParameters && substr(trim($limit ?? ''), 0, 1) == ':')) {
                 $limit = null;
             }
             if (!$extrapolateParameters && $this->limit instanceof UnquotedParameter && !isset($parameters[$this->limit->getName()])) {
@@ -385,7 +385,7 @@ class Select implements StatementInterface, NodeInterface
             }
             if (!empty($this->offset)) {
                 $offset = NodeFactory::toSql($this->offset, $platform, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);
-                if ($offset === '' || ($extrapolateParameters && substr(trim($offset), 0, 1) == ':')) {
+                if ($offset === '' || ($extrapolateParameters && substr(trim($offset ?? ''), 0, 1) == ':')) {
                     $offset = null;
                 }
                 if (!$extrapolateParameters && $this->offset instanceof UnquotedParameter && !isset($parameters[$this->offset->getName()])) {

--- a/src/SQLParser/Query/Select.php
+++ b/src/SQLParser/Query/Select.php
@@ -318,13 +318,13 @@ class Select implements StatementInterface, NodeInterface
      *
      * @param array $parameters
      * @param AbstractPlatform $platform
-     * @param int|number $indent
+     * @param int $indent
      * @param int $conditionsMode
      *
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $sql = 'SELECT ';
         if ($this->distinct) {

--- a/src/SQLParser/Query/Union.php
+++ b/src/SQLParser/Query/Union.php
@@ -3,6 +3,7 @@
 namespace SQLParser\Query;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Mouf\MoufInstanceDescriptor;
 use SQLParser\Node\NodeFactory;
 use Mouf\MoufManager;
@@ -65,17 +66,18 @@ class Union implements StatementInterface, NodeInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param array      $parameters
-     * @param Connection $dbConnection
+     * @param array $parameters
+     * @param AbstractPlatform $platform
      * @param int|number $indent
-     * @param int        $conditionsMode
+     * @param int $conditionsMode
      *
+     * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true)
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
-        $selectsSql = array_map(function(Select $select) use ($parameters, $dbConnection, $indent, $conditionsMode, $extrapolateParameters) {
-            return $select->toSql($parameters, $dbConnection, $indent, $conditionsMode, $extrapolateParameters);
+        $selectsSql = array_map(function(Select $select) use ($parameters, $platform, $indent, $conditionsMode, $extrapolateParameters) {
+            return $select->toSql($parameters, $platform, $indent, $conditionsMode, $extrapolateParameters);
         }, $this->selects);
 
         $sql = implode(' UNION ', $selectsSql);

--- a/src/SQLParser/Query/Union.php
+++ b/src/SQLParser/Query/Union.php
@@ -105,7 +105,7 @@ class Union implements StatementInterface, NodeInterface
     }
 
     /**
-     * @param Select[] $children
+     * @param (Select|null)[] $children
      * @param VisitorInterface $visitor
      */
     private function walkChildren(array &$children, VisitorInterface $visitor)

--- a/src/SQLParser/Query/Union.php
+++ b/src/SQLParser/Query/Union.php
@@ -68,13 +68,13 @@ class Union implements StatementInterface, NodeInterface
      *
      * @param array $parameters
      * @param AbstractPlatform $platform
-     * @param int|number $indent
+     * @param int $indent
      * @param int $conditionsMode
      *
      * @param bool $extrapolateParameters
      * @return string
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string
     {
         $selectsSql = array_map(function(Select $select) use ($parameters, $platform, $indent, $conditionsMode, $extrapolateParameters) {
             return $select->toSql($parameters, $platform, $indent, $conditionsMode, $extrapolateParameters);

--- a/src/SQLParser/SqlRenderInterface.php
+++ b/src/SQLParser/SqlRenderInterface.php
@@ -28,5 +28,5 @@ interface SqlRenderInterface
      *
      * @return string|null
      */
-    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string;
+    public function toSql(array $parameters, AbstractPlatform $platform, int $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string;
 }

--- a/src/SQLParser/SqlRenderInterface.php
+++ b/src/SQLParser/SqlRenderInterface.php
@@ -3,6 +3,7 @@
 namespace SQLParser;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 
 /**
  * Objects implementing SqlRenderInterface can be rendered with the toSql method.
@@ -19,13 +20,13 @@ interface SqlRenderInterface
     /**
      * Renders the object as a SQL string.
      *
-     * @param Connection $dbConnection
-     * @param array      $parameters
-     * @param int        $indent
-     * @param int        $conditionsMode
-     * @param bool       $extrapolateParameters Whether the parameters should be fed into the returned SQL query
+     * @param array $parameters
+     * @param AbstractPlatform $platform
+     * @param int $indent
+     * @param int $conditionsMode
+     * @param bool $extrapolateParameters Whether the parameters should be fed into the returned SQL query
      *
-     * @return string
+     * @return string|null
      */
-    public function toSql(array $parameters = array(), Connection $dbConnection = null, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true);
+    public function toSql(array $parameters, AbstractPlatform $platform, $indent = 0, $conditionsMode = self::CONDITION_APPLY, bool $extrapolateParameters = true): ?string;
 }

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -3,6 +3,7 @@
 namespace Mouf\Database;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Mouf\Database\SchemaAnalyzer\SchemaAnalyzer;
 use PHPUnit\Framework\TestCase;
@@ -433,5 +434,14 @@ class MagicQueryTest extends TestCase
         // Let's check that MagicQuery is cleverly adding parenthesis if the user forgot those in the "IN" statement.
         $sql = 'SELECT id FROM users WHERE status IN :status';
         $this->assertEquals("SELECT id FROM users WHERE status IN (:status)", self::simplifySql($magicQuery->buildPreparedStatement($sql, ['status' => [1,2]])));
+    }
+
+    public function testSetOutputDialect()
+    {
+        $magicQuery = new MagicQuery(null, new ArrayCache());
+        $magicQuery->setOutputDialect(new PostgreSqlPlatform());
+
+        $sql = 'SELECT id FROM users';
+        $this->assertEquals('SELECT "id" FROM "users"', self::simplifySql($magicQuery->buildPreparedStatement($sql)));
     }
 }

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -120,7 +120,7 @@ class MagicQueryTest extends TestCase
 
         // Test strings with "
         $sql = 'SELECT * FROM users WHERE status = \'"\'';
-        $this->assertEquals('SELECT * FROM users WHERE status = \'\\"\'', self::simplifySql($magicQuery->build($sql)));
+        $this->assertEquals('SELECT * FROM users WHERE status = \'"\'', self::simplifySql($magicQuery->build($sql)));
 
         $sql = 'SELECT 1+2 as toto FROM users';
         $this->assertEquals('SELECT 1 + 2 AS toto FROM users', self::simplifySql($magicQuery->build($sql)));


### PR DESCRIPTION
MagicQuery takes MySQL dialect in input, but outputs to the format expected by your database.

But if you want to cascade MagicQuery and re-enter SQL generated by MagicQuery (yes, this happens in TDBM), then you need the output to be in MySQL format too.

So we need a way to specify the output dialect.