### PR TITLE
Allowing to set to null the SQL dialect

### DIFF
--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -443,5 +443,11 @@ class MagicQueryTest extends TestCase
 
         $sql = 'SELECT id FROM users';
         $this->assertEquals('SELECT "id" FROM "users"', self::simplifySql($magicQuery->buildPreparedStatement($sql)));
+
+        $magicQuery->setOutputDialect(null);
+
+        $sql = 'SELECT id FROM users';
+        $this->assertEquals('SELECT id FROM users', self::simplifySql($magicQuery->buildPreparedStatement($sql)));
+
     }
 }


### PR DESCRIPTION
This PR allows to call `$magicQuery->setOutputDialect(null)`.

This resets the output dialect to the default settings (platform connection or MySQL).
Also fixes an issue with cache not being sensitive to output dialect.