### PR TITLE
Migrating to Twig 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     	"mouf/utils.common.paginable-interface": "~1.0",
     	"mouf/utils.common.sortable-interface": "~1.0",
         "mouf/schema-analyzer": "~1.0",
-        "twig/twig": "^2 || ^3",
+        "twig/twig": "^2.4 || ^3",
         "greenlion/php-sql-parser": "^4.1.2",
         "doctrine/cache": "^1.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     	"mouf/utils.common.paginable-interface": "~1.0",
     	"mouf/utils.common.sortable-interface": "~1.0",
         "mouf/schema-analyzer": "~1.0",
-        "twig/twig": "^1.34.4 || ^2",
+        "twig/twig": "^2 || ^3",
         "greenlion/php-sql-parser": "^4.1.2",
         "doctrine/cache": "^1.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     	"mouf/utils.common.paginable-interface": "~1.0",
     	"mouf/utils.common.sortable-interface": "~1.0",
         "mouf/schema-analyzer": "~1.0",
-        "twig/twig": "^2.4 || ^3",
+        "twig/twig": "^2.11 || ^3",
         "greenlion/php-sql-parser": "^4.1.2",
         "doctrine/cache": "^1.5"
     },

--- a/src/Mouf/Database/MagicQuery.php
+++ b/src/Mouf/Database/MagicQuery.php
@@ -5,6 +5,7 @@ namespace Mouf\Database;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Twig\Environment;
 use function array_filter;
 use function array_keys;
 use Doctrine\Common\Cache\VoidCache;
@@ -40,7 +41,7 @@ class MagicQuery
      */
     private $platform;
     /**
-     * @var \Twig_Environment
+     * @var Environment
      */
     private $twigEnvironment;
     private $enableTwig = false;
@@ -321,7 +322,7 @@ class MagicQuery
     }
 
     /**
-     * @return \Twig_Environment
+     * @return Environment
      */
     private function getTwigEnvironment()
     {

--- a/src/Mouf/Database/MagicQuery/Twig/SqlTwigEnvironmentFactory.php
+++ b/src/Mouf/Database/MagicQuery/Twig/SqlTwigEnvironmentFactory.php
@@ -2,6 +2,9 @@
 
 namespace Mouf\Database\MagicQuery\Twig;
 
+use Twig\Environment;
+use Twig\Extension\CoreExtension;
+use Twig\Extension\EscaperExtension;
 use Twig_Extension_Core;
 
 /**
@@ -26,14 +29,14 @@ class SqlTwigEnvironmentFactory
             'autoescape' => 'sql' // Default autoescape mode: sql
         );
 
-        $twig = new \Twig_Environment($stringLoader, $options);
+        $twig = new Environment($stringLoader, $options);
 
         // Default escaper will throw an exception. This is because we want to use SQL parameters instead of Twig.
         // This has a number of advantages, especially in terms of caching.
 
-        /** @var Twig_Extension_Core $twigExtensionCore */
-        $twigExtensionCore = $twig->getExtension('Twig_Extension_Core');
-        $twigExtensionCore->setEscaper('sql', function () {
+        /** @var EscaperExtension $twigExtensionEscaper */
+        $twigExtensionEscaper = $twig->getExtension(EscaperExtension::class);
+        $twigExtensionEscaper->setEscaper('sql', function () {
             throw new ForbiddenTwigParameterInSqlException('You cannot use Twig expressions (like "{{ id }}"). Instead, you should use SQL parameters (like ":id"). Twig integration is limited to Twig statements (like "{% for .... %}"');
         });
 

--- a/src/Mouf/Database/MagicQuery/Twig/StringLoader.php
+++ b/src/Mouf/Database/MagicQuery/Twig/StringLoader.php
@@ -1,6 +1,9 @@
 <?php
 
 namespace Mouf\Database\MagicQuery\Twig;
+use Twig\Error\LoaderError;
+use Twig\Loader\LoaderInterface;
+use Twig\Source;
 use Twig_Error_Loader;
 use Twig_Source;
 
@@ -12,7 +15,7 @@ use Twig_Source;
  * We enable it back in our case because there won't be a million of different cache keys.
  * And yes, we know what we are doing :)
  */
-class StringLoader implements \Twig_LoaderInterface
+class StringLoader implements LoaderInterface
 {
     /**
      * {@inheritdoc}
@@ -24,14 +27,14 @@ class StringLoader implements \Twig_LoaderInterface
     /**
      * {@inheritdoc}
      */
-    public function getCacheKey($name)
+    public function getCacheKey($name): string
     {
         return $name;
     }
     /**
      * {@inheritdoc}
      */
-    public function isFresh($name, $time)
+    public function isFresh($name, $time): bool
     {
         return true;
     }
@@ -41,13 +44,11 @@ class StringLoader implements \Twig_LoaderInterface
      *
      * @param string $name The template logical name
      *
-     * @return Twig_Source
-     *
-     * @throws Twig_Error_Loader When $name is not found
+     * @return Source
      */
-    public function getSourceContext($name)
+    public function getSourceContext($name): Source
     {
-        return new Twig_Source($name, $name);
+        return new Source($name, $name);
     }
 
     /**

--- a/tests/Mouf/Database/MagicQuery/Twig/SqlTwigEnvironmentFactoryTest.php
+++ b/tests/Mouf/Database/MagicQuery/Twig/SqlTwigEnvironmentFactoryTest.php
@@ -18,7 +18,7 @@ class SqlTwigEnvironmentFactoryTest extends TestCase
     }
 
     /**
-     * @expectedException Twig_Error_Runtime
+     * @expectedException \Twig\Error\RuntimeError
      */
     public function testException()
     {


### PR DESCRIPTION
This PR makes MagicQuery 1.4 compatible with Twig 2 and Twig 3 (rather than Twig 1 and Twig 2).
This way, MagicQuery 1.4 can target Symfony 5 applications