### PR TITLE
Fixing an issue if there is no alias in subquery

### DIFF
--- a/src/SQLParser/Node/NodeFactory.php
+++ b/src/SQLParser/Node/NodeFactory.php
@@ -42,7 +42,7 @@ class NodeFactory
 
                 // If the constant has an alias, it is declared in the columns section.
                 // If this is the case, let's wrap it in an "expression"
-                if (isset($desc['alias'])) {
+                if (isset($desc['alias']['name'])) {
                     $expression = new Expression();
                     $expression->setBaseExpression($desc['base_expr']);
                     $expression->setSubTree($const);
@@ -108,7 +108,7 @@ class NodeFactory
                         $instance->setDatabase($baseName);
                     }
 
-                    if (!empty($desc['alias'])) {
+                    if (!empty($desc['alias']['name'])) {
                         $instance->setAlias($desc['alias']['name']);
                     }
 
@@ -225,7 +225,7 @@ class NodeFactory
                     $expr->setJoinType($desc['join_type']);
                 }
 
-                if (isset($desc['alias'])) {
+                if (isset($desc['alias']['name'])) {
                     $expr->setAlias($desc['alias']['name']);
                 }
 
@@ -285,7 +285,7 @@ class NodeFactory
                     $expr->setSubTree(self::buildFromSubtree($desc['sub_tree']));
                 }
 
-                if (isset($desc['alias'])) {
+                if (isset($desc['alias']['name'])) {
                     $expr->setAlias($desc['alias']['name']);
                 }
                 if (isset($desc['direction'])) {

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -146,7 +146,7 @@ class MagicQueryTest extends TestCase
 
         $sql = "SELECT Substring_index(ee.`data`, ':', -1) as foo FROM users";
         $this->assertEquals("SELECT Substring_index(ee.data, ':', -1) AS foo FROM users", self::simplifySql($magicQuery->build($sql)));
-        
+
         $sql = 'SELECT * FROM users GROUP BY id, login';
         $this->assertEquals('SELECT * FROM users GROUP BY id, login', self::simplifySql($magicQuery->build($sql)));
 
@@ -201,6 +201,9 @@ class MagicQueryTest extends TestCase
         $this->assertEquals($sql, self::simplifySql($magicQuery->build($sql)));
 
         $sql = 'SELECT (id + 2) AS foo FROM bar';
+        $this->assertEquals($sql, self::simplifySql($magicQuery->build($sql)));
+
+        $sql = 'SELECT COUNT(*) FROM (SELECT DISTINCT `states`.`country_id`, `states`.`code` FROM states)';
         $this->assertEquals($sql, self::simplifySql($magicQuery->build($sql)));
     }
 
@@ -380,9 +383,9 @@ class MagicQueryTest extends TestCase
             ORDER BY MATCH(column) AGAINST(:searchTerm IN BOOLEAN MODE) DESC
         ";
         $expectedSql = "SELECT MATCH(column) AGAINST('searchString' IN BOOLEAN MODE) AS rang FROM table WHERE MATCH(column) AGAINST('searchString' IN BOOLEAN MODE) ORDER BY MATCH(column) AGAINST('searchString' IN BOOLEAN MODE) DESC";
-        
+
         $params["searchTerm"] = "searchString";
-        
+
         $this->assertEquals($expectedSql, self::simplifySql($magicQuery->build($sql, $params)));
     }
 

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -203,7 +203,7 @@ class MagicQueryTest extends TestCase
         $sql = 'SELECT (id + 2) AS foo FROM bar';
         $this->assertEquals($sql, self::simplifySql($magicQuery->build($sql)));
 
-        $sql = 'SELECT COUNT(*) FROM (SELECT DISTINCT `states`.`country_id`, `states`.`code` FROM states)';
+        $sql = 'SELECT COUNT(*) FROM (SELECT DISTINCT states.country_id, states.code FROM states)';
         $this->assertEquals($sql, self::simplifySql($magicQuery->build($sql)));
     }
 


### PR DESCRIPTION
This PR fixes an issue with query of the type:

`SELECT COUNT(*) FROM (SELECT DISTINCT `states`.`country_id`, `states`.`code` FROM states)`

(with no alias in the subquery).

Starts with a failing test