### PR TITLE
In Oracle, table aliases cannot contain the AS keyword

### DIFF
--- a/src/SQLParser/Node/Table.php
+++ b/src/SQLParser/Node/Table.php
@@ -229,7 +229,7 @@ class Table implements NodeInterface
         }
         $sql .= $platform->quoteSingleIdentifier($this->table);
         if ($this->alias) {
-            $sql .= ' AS '.$platform->quoteSingleIdentifier($this->alias);
+            $sql .= ' '.$platform->quoteSingleIdentifier($this->alias);
         }
         if ($this->hints) {
             foreach ($this->hints as $hint) {

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -189,10 +189,10 @@ class MagicQueryTest extends TestCase
         $this->assertEquals('SELECT a FROM users UNION SELECT a FROM users', self::simplifySql($magicQuery->build($sql)));
 
         $sql = 'SELECT a FROM users u, users u2';
-        $this->assertEquals('SELECT a FROM users AS u CROSS JOIN users u2', self::simplifySql($magicQuery->build($sql)));
+        $this->assertEquals('SELECT a FROM users u CROSS JOIN users u2', self::simplifySql($magicQuery->build($sql)));
 
         $sql = 'SELECT a FROM users u WHERE status = (CASE WHEN u.id = 1 THEN u.status_1 ELSE u.status_2 END)';
-        $this->assertEquals('SELECT a FROM users AS u WHERE status = (CASE WHEN u.id = 1 THEN u.status_1 ELSE u.status_2 END)', self::simplifySql($magicQuery->build($sql)));
+        $this->assertEquals('SELECT a FROM users u WHERE status = (CASE WHEN u.id = 1 THEN u.status_1 ELSE u.status_2 END)', self::simplifySql($magicQuery->build($sql)));
 
         $sql = 'SELECT 42 as fooalias FROM bar HAVING fooalias = 24';
         $this->assertEquals('SELECT 42 AS fooalias FROM bar HAVING fooalias = 24', self::simplifySql($magicQuery->build($sql)));

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -189,7 +189,7 @@ class MagicQueryTest extends TestCase
         $this->assertEquals('SELECT a FROM users UNION SELECT a FROM users', self::simplifySql($magicQuery->build($sql)));
 
         $sql = 'SELECT a FROM users u, users u2';
-        $this->assertEquals('SELECT a FROM users AS u CROSS JOIN users AS u2', self::simplifySql($magicQuery->build($sql)));
+        $this->assertEquals('SELECT a FROM users AS u CROSS JOIN users u2', self::simplifySql($magicQuery->build($sql)));
 
         $sql = 'SELECT a FROM users u WHERE status = (CASE WHEN u.id = 1 THEN u.status_1 ELSE u.status_2 END)';
         $this->assertEquals('SELECT a FROM users AS u WHERE status = (CASE WHEN u.id = 1 THEN u.status_1 ELSE u.status_2 END)', self::simplifySql($magicQuery->build($sql)));


### PR DESCRIPTION
See https://www.techonthenet.com/oracle/alias.php

PR starts with a failing test for Oracle