### PR TITLE
Update deps + test on dbal v3

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -140,7 +140,9 @@ jobs:
         run: "vendor/bin/phpunit"
 
       - name: "Run Coveralls"
-        run: "vendor/bin/coveralls -v"
+        run: "vendor/bin/php-coveralls -v"
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   phpunit:
     name: "PHPUnit"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 phpunit.xml
 build/
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "satooshi/php-coveralls": "~1.0",
-        "doctrine/dbal": "~2.5",
+        "php-coveralls/php-coveralls": "^2.0.0",
+        "doctrine/dbal": "^3.0",
         "phpstan/phpstan": "^0.12.82"
     },
     "suggest": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,7 @@ parameters:
     inferPrivatePropertyTypeFromConstructor: true
     checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
+    reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         - "#Mouf\\\\MoufManager#"
         - "#Mouf\\\\MoufInstanceDescriptor#"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="tests/bootstrap.php"
+<phpunit 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    backupGlobals="false" 
+    backupStaticAttributes="false" 
+    colors="true" 
+    convertErrorsToExceptions="true" 
+    convertNoticesToExceptions="true" 
+    convertWarningsToExceptions="true" 
+    processIsolation="false" 
+    stopOnFailure="false" 
+    bootstrap="tests/bootstrap.php" 
 >
-
-    <php>
-        <var name="db_host" value="127.0.0.1" />
-        <var name="db_port" value="3306"/>
-        <var name="db_username" value="root" />
-        <var name="db_password" value="" />
-        <var name="db_driver" value="pdo_mysql"/>
-    </php>
-
-    <testsuites>
-        <testsuite name="Mouf Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="build/coverage" />
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+    </report>
+  </coverage>
+  <php>
+    <var name="db_host" value="127.0.0.1"/>
+    <var name="db_port" value="3306"/>
+    <var name="db_username" value="root"/>
+    <var name="db_password" value=""/>
+    <var name="db_driver" value="pdo_mysql"/>
+  </php>
+  <testsuites>
+    <testsuite name="Mouf Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/src/Mouf/Database/QueryWriter/CountNbResult.php
+++ b/src/Mouf/Database/QueryWriter/CountNbResult.php
@@ -50,6 +50,6 @@ class CountNbResult implements IntValueInterface
     {
         $sql = 'SELECT count(*) as cnt FROM ('.$this->queryResult->toSql().') tmp';
 
-        return $this->connection->fetchColumn($sql);
+        return $this->connection->fetchOne($sql);
     }
 }

--- a/src/Mouf/Database/QueryWriter/QueryResult.php
+++ b/src/Mouf/Database/QueryWriter/QueryResult.php
@@ -77,9 +77,9 @@ class QueryResult implements ArrayValueInterface, PaginableInterface, SortableIn
     public function val()
     {
         $parameters = ValueUtils::val($this->parameters);
-        $pdoStatement = $this->connection->query($this->select->toSql($parameters, $this->connection->getDatabasePlatform()).DbHelper::getFromLimitString($this->offset, $this->limit));
+        $pdoStatement = $this->connection->prepare($this->select->toSql($parameters, $this->connection->getDatabasePlatform()).DbHelper::getFromLimitString($this->offset, $this->limit));
 
-        return new ResultSet($pdoStatement);
+        return new ResultSet($pdoStatement->getWrappedStatement());
     }
 
     /**

--- a/src/Mouf/Database/QueryWriter/ResultSet.php
+++ b/src/Mouf/Database/QueryWriter/ResultSet.php
@@ -2,7 +2,6 @@
 
 namespace Mouf\Database\QueryWriter;
 
-use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Driver\Statement;
 
 /**
@@ -16,7 +15,7 @@ class ResultSet implements \Iterator
     private $statement;
     /** @var int */
     private $key = 0;
-    /** @var array|false */
+    /** @var array */
     private $result;
     /** @var bool */
     private $fetched = false;
@@ -28,7 +27,7 @@ class ResultSet implements \Iterator
         $this->statement = $statement;
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         ++$this->rewindCalls;
         if ($this->rewindCalls == 2) {
@@ -36,10 +35,7 @@ class ResultSet implements \Iterator
         }
     }
 
-    /**
-     * @return array|false
-     */
-    public function current()
+    public function current(): array
     {
         if (!$this->fetched) {
             $this->fetch();
@@ -48,15 +44,12 @@ class ResultSet implements \Iterator
         return $this->result;
     }
 
-    /**
-     * @return int
-     */
-    public function key()
+    public function key(): int
     {
         return $this->key;
     }
 
-    public function next()
+    public function next(): void
     {
         ++$this->key;
         $this->fetched = false;
@@ -65,11 +58,11 @@ class ResultSet implements \Iterator
 
     private function fetch(): void
     {
-        $this->result = $this->statement->fetch(FetchMode::ASSOCIATIVE);
+        $this->result = $this->statement->execute()->fetchAllAssociative();
         $this->fetched = true;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         if (!$this->fetched) {
             $this->fetch();

--- a/src/SQLParser/Node/NodeFactory.php
+++ b/src/SQLParser/Node/NodeFactory.php
@@ -653,7 +653,9 @@ class NodeFactory
                     if (empty($operand->getBaseExpression())) {
                         $subTree = $operand->getSubTree();
                         if (is_array($subTree) && count($subTree) === 1) {
-                            $newNodes = array_merge($newNodes, self::simplify($subTree));
+                            $simplifiedSubTree = self::simplify($subTree);
+                            \assert(is_array($simplifiedSubTree));
+                            $newNodes = array_merge($newNodes, $simplifiedSubTree);
                         } else {
                             $newNodes[] = $operand;
                         }

--- a/tests/Mouf/Database/MagicQuery/Twig/SqlTwigEnvironmentFactoryTest.php
+++ b/tests/Mouf/Database/MagicQuery/Twig/SqlTwigEnvironmentFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Mouf\Database;
+namespace Mouf\Database\MagicQuery\Twig;
 
 use Mouf\Database\MagicQuery\Twig\SqlTwigEnvironmentFactory;
 use PHPUnit\Framework\TestCase;

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -3,6 +3,7 @@
 namespace Mouf\Database;
 
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\DBAL\Platforms\PostgreSQL100Platform;
 use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use Mouf\Database\SchemaAnalyzer\SchemaAnalyzer;
@@ -459,7 +460,7 @@ class MagicQueryTest extends TestCase
     public function testSetOutputDialect()
     {
         $magicQuery = new MagicQuery(null, new ArrayCache());
-        $magicQuery->setOutputDialect(new PostgreSqlPlatform());
+        $magicQuery->setOutputDialect(new PostgreSQL100Platform());
 
         $sql = 'SELECT id FROM users';
         $this->assertEquals('SELECT "id" FROM "users"', self::simplifySql($magicQuery->buildPreparedStatement($sql)));

--- a/tests/phpunit-mysql8.sh
+++ b/tests/phpunit-mysql8.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Use this file to start a MySQL8 database using Docker and then run the test suite on the MySQL8 database.
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+cd ..
+
+docker run --rm --name mysql8-magic-query-test -p 3306:3306 -p 33060:33060 -e MYSQL_ROOT_PASSWORD= -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -d mysql:8 mysqld --default-authentication-plugin=mysql_native_password
+
+# Let's wait for MySQL 8 to start
+sleep 20
+
+vendor/bin/phpunit -c phpunit.xml.dist $NO_COVERAGE
+RESULT_CODE=$?
+
+docker stop mysql8-magic-query-test
+
+exit $RESULT_CODE


### PR DESCRIPTION
After updating schema-analyzer in https://github.com/thecodingmachine/schema-analyzer/pull/13

Follow up of https://github.com/thecodingmachine/magic-query/commit/0c0ab130be9cca5bf4977ff4f12e6def7d87b046 to support v2 of schema analyzer

- Updates dev deps
- Fixes coverage in ci
- Migrate phpunit config to newer schema
- Ignore unmatched errors in phpstan
- Adds asserts to fix phpstan errors
- Fixes methods accessing dbal v3
- Use mysql80/postgressql10 platforms (the normal ones throwed class not found exception)
- Add test script to test with myql locally

