### PR TITLE
Add support for UNION ALL and UNION DISTINCT

### DIFF
--- a/src/SQLParser/Query/Union.php
+++ b/src/SQLParser/Query/Union.php
@@ -26,12 +26,18 @@ class Union implements StatementInterface, NodeInterface
     private $selects;
 
     /**
+     * @var bool
+     */
+    private $isUnionAll;
+
+    /**
      * Union constructor.
      * @param Select[] $selects
      */
-    public function __construct(array $selects)
+    public function __construct(array $selects, bool $isUnionAll)
     {
         $this->selects = $selects;
+        $this->isUnionAll = $isUnionAll;
     }
 
     /** @var NodeInterface[]|NodeInterface */
@@ -105,7 +111,9 @@ class Union implements StatementInterface, NodeInterface
             return $select->toSql($parameters, $platform, $indent, $conditionsMode, $extrapolateParameters);
         }, $this->selects);
 
-        $sql = '(' . implode(') UNION (', $selectsSql) . ')';
+        $unionStatement = $this->isUnionAll ? 'UNION ALL' : 'UNION';
+
+        $sql = '(' . implode(') ' . $unionStatement . ' (', $selectsSql) . ')';
 
         if (!empty($this->order)) {
             $order = NodeFactory::toSql($this->order, $platform, $parameters, ',', false, $indent + 2, $conditionsMode, $extrapolateParameters);

--- a/tests/Mouf/Database/MagicQueryTest.php
+++ b/tests/Mouf/Database/MagicQueryTest.php
@@ -188,6 +188,12 @@ class MagicQueryTest extends TestCase
         $sql = 'SELECT a FROM users UNION SELECT a FROM users';
         $this->assertEquals('(SELECT a FROM users) UNION (SELECT a FROM users)', self::simplifySql($magicQuery->build($sql)));
 
+        $sql = 'SELECT a FROM users UNION ALL SELECT a FROM users';
+        $this->assertEquals('(SELECT a FROM users) UNION ALL (SELECT a FROM users)', self::simplifySql($magicQuery->build($sql)));
+
+        $sql = 'SELECT a FROM users UNION DISTINCT SELECT a FROM users';
+        $this->assertEquals('(SELECT a FROM users) UNION (SELECT a FROM users)', self::simplifySql($magicQuery->build($sql)));
+
         $sql = 'SELECT a FROM users u, users u2';
         $this->assertEquals('SELECT a FROM users u CROSS JOIN users u2', self::simplifySql($magicQuery->build($sql)));
 


### PR DESCRIPTION
The code now supports UNION ALL and UNION DISTINCT statements in addition to the standard UNION. The MagicQueryTest.php file has been updated with added test cases to reflect these changes. Union.php and StatementFactory.php were modified to handle the additional logic required for the new union types.

Related to issue #88 